### PR TITLE
Remove leading slashes from Consul keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
 language: ruby
+dist: xenial
+
+branches:
+  only:
+    - master
+
 rvm:
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+
+before_install:
+  - gem install bundler
+
 bundler_args: --binstubs
+
 script: "bin/rspec --format doc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consul-template-generator (0.3.5)
+    consul-template-generator (0.3.6)
       diffy (~> 3.0)
       diplomat (~> 0.13)
       popen4 (~> 0.1)
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     Platform (0.4.2)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
     crack (0.4.3)
@@ -23,31 +23,31 @@ GEM
     docile (1.3.1)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    hashdiff (0.3.8)
+    hashdiff (0.3.9)
     hirb (0.7.3)
-    json (2.1.0)
+    json (2.2.0)
     multipart-post (2.0.0)
     open4 (1.3.4)
     popen4 (0.1.2)
       Platform (>= 0.4.0)
       open4 (>= 0.4.0)
     public_suffix (3.0.3)
-    rack (1.6.11)
-    rake (10.5.0)
+    rack (2.0.7)
+    rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -57,7 +57,7 @@ GEM
       hirb
       simplecov
     simplecov-html (0.10.2)
-    webmock (1.24.6)
+    webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -66,14 +66,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.7)
+  bundler (~> 2.0)
   consul-template-generator!
-  rack (~> 1.6)
-  rake (~> 10.0)
+  rack (~> 2.0)
+  rake (~> 12.0)
   rspec (~> 3.3)
   simplecov (~> 0.10)
   simplecov-console (~> 0.2)
-  webmock (~> 1.21)
+  webmock (~> 3.5)
 
 BUNDLED WITH
    2.0.1

--- a/consul-template-generator.gemspec
+++ b/consul-template-generator.gemspec
@@ -18,14 +18,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_dependency 'diffy', '~> 3.0'
+  spec.add_dependency 'diplomat', '~> 0.18.0'
+  spec.add_dependency 'popen4', '~> 0.1'
+
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rack', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'simplecov', '~> 0.10'
   spec.add_development_dependency 'simplecov-console', '~> 0.2'
-  spec.add_development_dependency 'webmock', '~> 1.21'
-  spec.add_development_dependency 'rack', '~> 1.6'
-  spec.add_dependency 'diffy', '~> 3.0'
-  spec.add_dependency 'diplomat', '~> 0.13'
-  spec.add_dependency 'popen4', '~> 0.1'
+  spec.add_development_dependency 'webmock', '~> 3.5'
 end

--- a/lib/consul/template/generator/configuration.rb
+++ b/lib/consul/template/generator/configuration.rb
@@ -60,7 +60,7 @@ module Consul
         end
 
         def lock_key(key)
-          "/lock/#{key.sub(/^\//, '')}"
+          "lock/#{key.sub(/^\//, '')}"
         end
 
         def session_lock_key

--- a/lib/consul/template/generator/version.rb
+++ b/lib/consul/template/generator/version.rb
@@ -1,7 +1,7 @@
 module Consul
   module Template
     module Generator
-      VERSION = '0.3.5'
+      VERSION = '0.3.6'
     end
   end
 end

--- a/spec/key_value_spec.rb
+++ b/spec/key_value_spec.rb
@@ -10,7 +10,7 @@ include Consul::Template::Generator
 describe 'Consul::Template::Generator::CTRunner' '#acquire_lock' do
   before do
     Consul::Template::Generator.configure do |config|
-      config.templates = { 'test-template.ctmpl' => '/test-template' }
+      config.templates = { 'test-template.ctmpl' => 'test-template' }
       config.consul_host = '127.0.0.1:8500'
       config.consul_template_binary = 'consul-template'
       config.log_level = :off
@@ -40,7 +40,7 @@ end
 describe 'Consul::Template::Generator::CTRunner' '#acquire_session_lock' do
   before do
     Consul::Template::Generator.configure do |config|
-      config.templates = { 'test-template.ctmpl' => '/test-template' }
+      config.templates = { 'test-template.ctmpl' => 'test-template' }
       config.session_key = '/session/test-template'
       config.consul_host = '127.0.0.1:8500'
       config.consul_template_binary = 'consul-template'
@@ -71,7 +71,7 @@ describe 'Consul::Template::Generator::CTRunner' '#upload_template' do
   context 'uploads template' do
     before do
       Consul::Template::Generator.configure do |config|
-        config.templates = { 'test-template.ctmpl' => '/test-template' }
+        config.templates = { 'test-template.ctmpl' => 'test-template' }
         config.consul_host = '127.0.0.1:8500'
         config.consul_template_binary = 'consul-template'
         config.log_level = :off
@@ -90,7 +90,7 @@ describe 'Consul::Template::Generator::CTRunner' '#upload_template' do
   context 'handles template upload failure' do
     before do
       Consul::Template::Generator.configure do |config|
-        config.templates = { 'test-template.ctmpl' => '/test-template-failure' }
+        config.templates = { 'test-template.ctmpl' => 'test-template-failure' }
         config.consul_host = '127.0.0.1:8500'
         config.consul_template_binary = 'consul-template'
         config.log_level = :off

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,10 +97,7 @@ RSpec.configure do |config|
 
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::Console
-]
+SimpleCov.formatter = SimpleCov::Formatter::Console
 SimpleCov.minimum_coverage(80)
 SimpleCov.start
 


### PR DESCRIPTION
There's eventually a join that results in hitting the Consul API with
double-slash URIs like `/v1/kv//lock/session/thing`.

And newer versions of Ruby behave differently when given these.

Ruby 1.9:

```
irb(main):003:0> URI('http://127.0.0.1:8500') + '/pants//shirts'
=> #<URI::HTTP:0x00000001044268 URL:http://127.0.0.1:8500/pants/shirts>
```

Ruby 2.5:

```
irb(main):011:0> URI('http://127.0.0.1:8500') + '/pants//shirts'
=> #<URI::HTTP http://127.0.0.1:8500/pants//shirts>
```

The extra slash no longer being stripped results in the Consul API returning a
301 redirect to the same URI without the slash.

This is why the tests were failing under Ruby 2.5+ with complaints about the
expected request URLs being wrong.